### PR TITLE
Delete files now specifying URI instead of file URI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ PhoneGap plugin for managing application assets with javascript asset maps. Incl
 
 ### downloadFile()
 
-**wizAssets.downloadFile(String URL, String URI, Function success, Function fail);**
+**wizAssets.downloadFile(String remoteURL, String localURI, Function success, Function fail);**
 
 - downloads a file to native App directory @ ./ + gameDir+ / +filePathToBeStoredWithFilename <br />
 - A success returns a file URI string like; file://documents/settings/img/cards/card001.jpg <br />
@@ -36,7 +36,7 @@ wizAssets.downloadFile("http://google.com/logo.jpg", "img/ui/logo.jpg", successC
 
 ###  deleteFile()
 
-**wizAssets.deleteFile(string URI, Function success, Function fail);**
+**wizAssets.deleteFile(string localURI, Function success, Function fail);**
 
 - deletes the file specified by the URI <br />
 - if the URI does not exist fail will be called with error NotFoundError <br />
@@ -48,7 +48,7 @@ wizAssets.deleteFile("file://documents/settings/img/cards/card001.jpg", successC
 
 ### deleteFiles()
 
-**wizAssets.deleteFiles(Array URIs, Function success, Function fail );**
+**wizAssets.deleteFiles(Array localURIs, Function success, Function fail );**
 
 - delete all URIs in Array like; [ "img/cards/card001.jpg", "img/cards/card002.jpg " .. ] <br />
 - if you do not specify a filename only dir, then all contents of dir will be deleted; img/cards <br />
@@ -56,7 +56,7 @@ wizAssets.deleteFile("file://documents/settings/img/cards/card001.jpg", successC
 
 ### getFileURI()
 
-**wizAssets.getFileURI(String URI, Function success, Function fail);**
+**wizAssets.getFileURI(String localURI, Function success, Function fail);**
 
 - A success returns a file URI string like file://documents/settings/img/cards/card001.jpg <br />
 - example;

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ PhoneGap plugin for managing application assets with javascript asset maps. Incl
 
 ### downloadFile()
 
-**wizAssets.downloadFile(String URL, String filePathToBeStoredWithFilename, Function success, Function fail);**
+**wizAssets.downloadFile(String URL, String URI, Function success, Function fail);**
 
 - downloads a file to native App directory @ ./ + gameDir+ / +filePathToBeStoredWithFilename <br />
-- A success returns URI string like; file://documents/settings/img/cards/card001.jpg <br />
+- A success returns a file URI string like; file://documents/settings/img/cards/card001.jpg <br />
 - example;
 
 ``` 
@@ -48,17 +48,17 @@ wizAssets.deleteFile("file://documents/settings/img/cards/card001.jpg", successC
 
 ### deleteFiles()
 
-**wizAssets.deleteFiles(Array manyURIs, Function success, Function fail );**
+**wizAssets.deleteFiles(Array URIs, Function success, Function fail );**
 
-- delete all URIs in Array like; [ "file://documents/settings/img/cards/card001.jpg", "file://documents/settings/img/cards/card002.jpg " .. ] <br />
-- if you do not specify a filename only dir, then all contents of dir will be deleted; file://documents/settings/img/cards <br />
+- delete all URIs in Array like; [ "img/cards/card001.jpg", "img/cards/card002.jpg " .. ] <br />
+- if you do not specify a filename only dir, then all contents of dir will be deleted; img/cards <br />
 - the array CAN contain one URI string
 
 ### getFileURI()
 
-**wizAssets.getFileURI(String filePathWithFilename, Function success, Function fail);**
+**wizAssets.getFileURI(String URI, Function success, Function fail);**
 
-- A success returns URI string like file://documents/settings/img/cards/card001.jpg <br />
+- A success returns a file URI string like file://documents/settings/img/cards/card001.jpg <br />
 - example;
 
 ```
@@ -69,7 +69,7 @@ wizAssets.getFileURI("img/ui/logo.jpg", successCallback, failCallback);
 
 **wizAssets.getFileURIs(Function success, Function fail);**
 
-- A success returns URI hashmap such as
+- A success returns a file URI hashmap such as
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Description
 
-PhoneGap plugin for managing application assets with javascript asset maps. Includes( iOS background threaded) downloadFile, getFileURI, getFileURIs, deleteFile.
+PhoneGap plugin for managing application assets with javascript asset maps. Includes (iOS background threaded) downloadFile, getFileURI, getFileURIs, deleteFile, deleteFiles.
 
 
 ## Install (with Plugman) 
@@ -24,23 +24,23 @@ PhoneGap plugin for managing application assets with javascript asset maps. Incl
 
 ### downloadFile()
 
-**wizAssets.downloadFile(String remoteURL, String localURI, Function success, Function fail);**
+**wizAssets.downloadFile(String remoteURL, String assetId, Function success, Function fail);**
 
 - downloads a file to native App directory @ ./ + gameDir+ / +filePathToBeStoredWithFilename <br />
-- A success returns a file URI string like; file://documents/settings/img/cards/card001.jpg <br />
+- A success returns a local URL string like; file://documents/settings/img/cards/card001.jpg <br />
 - example;
 
 ``` 
 wizAssets.downloadFile("http://google.com/logo.jpg", "img/ui/logo.jpg", successCallback, failCallback);
 ```
 
-###  deleteFile()
+### deleteFile()
 
-**wizAssets.deleteFile(string localURI, Function success, Function fail);**
+**wizAssets.deleteFile(string assetId, Function success, Function fail);**
 
-- deletes the file specified by the URI <br />
-- if the URI does not exist fail will be called with error NotFoundError <br />
-- if the URI cannot be deleted (i.e. file resides in read-only memory) fail will be called with error NotModificationAllowedError
+- deletes the file specified by the asset id <br />
+- if the asset id does not exist fail will be called with error NotFoundError <br />
+- if the asset id cannot be deleted (i.e. file resides in read-only memory) fail will be called with error NotModificationAllowedError
 
 ```
 wizAssets.deleteFile("file://documents/settings/img/cards/card001.jpg", successCallback, failCallback);
@@ -48,17 +48,17 @@ wizAssets.deleteFile("file://documents/settings/img/cards/card001.jpg", successC
 
 ### deleteFiles()
 
-**wizAssets.deleteFiles(Array localURIs, Function success, Function fail );**
+**wizAssets.deleteFiles(Array assetIds, Function success, Function fail );**
 
-- delete all URIs in Array like; [ "img/cards/card001.jpg", "img/cards/card002.jpg " .. ] <br />
-- if you do not specify a filename only dir, then all contents of dir will be deleted; img/cards <br />
-- the array CAN contain one URI string
+- delete files specified by their asset id in Array like; [ "img/cards/card001.jpg", "img/cards/card002.jpg " .. ] <br />
+- if an asset id uses a path format and matches a folder, then the folder content will be deleted; img/cards <br />
+- the array CAN contain one asset id
 
 ### getFileURI()
 
-**wizAssets.getFileURI(String localURI, Function success, Function fail);**
+**wizAssets.getFileURI(String assetId, Function success, Function fail);**
 
-- A success returns a file URI string like file://documents/settings/img/cards/card001.jpg <br />
+- A success returns a local URL string like file://documents/settings/img/cards/card001.jpg <br />
 - example;
 
 ```
@@ -69,7 +69,7 @@ wizAssets.getFileURI("img/ui/logo.jpg", successCallback, failCallback);
 
 **wizAssets.getFileURIs(Function success, Function fail);**
 
-- A success returns a file URI hashmap such as
+- A success returns a hashmap of asset id matching its local URL such as
 
 ```
 {

--- a/platforms/android/assets/www/index.html
+++ b/platforms/android/assets/www/index.html
@@ -372,36 +372,24 @@
             );
         }
         
-        function deleteFile(path, download_button, delete_button, img) {
+        function deleteFile(uri, download_button, delete_button, img) {
             
-            // Define success callback for getting the URI.
-            function getFileURISuccessCallback(fileUri) {
-                
-                // Define success callback for deleting the URI.
-                function deleteFileSuccessCallback() {
-                    // Hide the image, enable download button, and disable delete button
-                    hideImage(img);
-                    document.getElementById(download_button).disabled = false;
-                    document.getElementById(delete_button).disabled = true;
-                    alert("Delete Success:\n" + path + "\nURI:\n" + fileUri);
-                }
-                
-                // Define error callback for deleting the URI.
-                function deleteFileErrorCallback(error) {
-                    alert("Delete Fail:\n" + error + "\nFile was probably already deleted.");
-                }
-                
-                // Delete the URI (and invoke appropriate callback).
-                window.wizAssets.deleteFile(fileUri, deleteFileSuccessCallback, deleteFileErrorCallback);
+            // Define success callback for deleting the URI.
+            function deleteFileSuccessCallback() {
+                // Hide the image, enable download button, and disable delete button
+                hideImage(img);
+                document.getElementById(download_button).disabled = false;
+                document.getElementById(delete_button).disabled = true;
+                alert("Delete Success:\n" + uri);
             }
 
-            // Define error callback for getting the URI.
-            function getFileURIErrorCallback(error) {
-                alert("Failed to get file URI error: " + error);
+            // Define error callback for deleting the URI.
+            function deleteFileErrorCallback(error) {
+                alert("Delete Fail:\n" + error + "\nFile was probably already deleted.");
             }
             
-            // Get the URI (and invoke appropriate callback).
-            window.wizAssets.getFileURI(path, getFileURISuccessCallback, getFileURIErrorCallback);
+            // Delete the URI (and invoke appropriate callback).
+            window.wizAssets.deleteFile(uri, deleteFileSuccessCallback, deleteFileErrorCallback);
         }
 
         function getFileURI(path) {
@@ -459,11 +447,8 @@
                 }
 
                 // Delete the URIs (and invoke appropriate callback).
-                alert( "Deleting " + Object.keys(fileUriMap).length + " files" );
-                var files = [];
-                for ( var key in fileUriMap) {
-                    files.push( fileUriMap[key] );
-                }
+                var files = Object.keys(fileUriMap);
+                alert("Deleting " + files.length + " files");
                 window.wizAssets.deleteFiles(files, deleteFilesSuccessCallback, deleteFilesErrorCallback);
             }
 

--- a/platforms/ios/www/index.html
+++ b/platforms/ios/www/index.html
@@ -372,36 +372,24 @@
             );
         }
         
-        function deleteFile(path, download_button, delete_button, img) {
+        function deleteFile(uri, download_button, delete_button, img) {
             
-            // Define success callback for getting the URI.
-            function getFileURISuccessCallback(fileUri) {
-                
-                // Define success callback for deleting the URI.
-                function deleteFileSuccessCallback() {
-                    // Hide the image, enable download button, and disable delete button
-                    hideImage(img);
-                    document.getElementById(download_button).disabled = false;
-                    document.getElementById(delete_button).disabled = true;
-                    alert("Delete Success:\n" + path + "\nURI:\n" + fileUri);
-                }
-                
-                // Define error callback for deleting the URI.
-                function deleteFileErrorCallback(error) {
-                    alert("Delete Fail:\n" + error + "\nFile was probably already deleted.");
-                }
-                
-                // Delete the URI (and invoke appropriate callback).
-                window.wizAssets.deleteFile(fileUri, deleteFileSuccessCallback, deleteFileErrorCallback);
+            // Define success callback for deleting the URI.
+            function deleteFileSuccessCallback() {
+                // Hide the image, enable download button, and disable delete button
+                hideImage(img);
+                document.getElementById(download_button).disabled = false;
+                document.getElementById(delete_button).disabled = true;
+                alert("Delete Success:\n" + uri);
             }
 
-            // Define error callback for getting the URI.
-            function getFileURIErrorCallback(error) {
-                alert("Failed to get file URI error: " + error);
+            // Define error callback for deleting the URI.
+            function deleteFileErrorCallback(error) {
+                alert("Delete Fail:\n" + error + "\nFile was probably already deleted.");
             }
             
-            // Get the URI (and invoke appropriate callback).
-            window.wizAssets.getFileURI(path, getFileURISuccessCallback, getFileURIErrorCallback);
+            // Delete the URI (and invoke appropriate callback).
+            window.wizAssets.deleteFile(uri, deleteFileSuccessCallback, deleteFileErrorCallback);
         }
 
         function getFileURI(path) {
@@ -459,11 +447,8 @@
                 }
 
                 // Delete the URIs (and invoke appropriate callback).
-                alert( "Deleting " + Object.keys(fileUriMap).length + " files" );
-                var files = [];
-                for ( var key in fileUriMap) {
-                    files.push( fileUriMap[key] );
-                }
+                var files = Object.keys(fileUriMap);
+                alert("Deleting " + files.length + " files");
                 window.wizAssets.deleteFiles(files, deleteFilesSuccessCallback, deleteFilesErrorCallback);
             }
 


### PR DESCRIPTION
Files are now deleted specifying the same URI given at download time instead of its file URI.

This will break with previous versions of wizAssets. wizAssets major version will have to be bumped at release.

poke @ronkorving @micky2be @wizcorp-olivier for potential reviews.