### PR TITLE
Use NSURLSession to download files on iOS and update error returned on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # phonegap-plugin-wizAssets 
 
 - PhoneGap Version : 3.0
-- last update : 15/11/2013
+- last update : 23/05/2016
 
 # Description
 
-PhoneGap plugin for managing application assets with javascript asset maps. Includes (iOS background threaded) downloadFile, getFileURI, getFileURIs, deleteFile, deleteFiles.
+PhoneGap plugin for managing application assets with javascript asset maps. Includes downloadFile, getFileURI, getFileURIs, deleteFile, deleteFiles.
 
 
 ## Install (with Plugman) 
@@ -22,54 +22,62 @@ PhoneGap plugin for managing application assets with javascript asset maps. Incl
 
 ## APIs
 
-### downloadFile()
+### wizAssets.downloadFile(remoteURL, assetId, success, fail)
 
-**wizAssets.downloadFile(String remoteURL, String assetId, Function success, Function fail);**
-
-- downloads a file to native App directory @ ./ + gameDir+ / +filePathToBeStoredWithFilename <br />
+- downloads a file to native App directory @ ./ + gameDir+ / + assetId <br />
 - A success returns a local URL string like; file://documents/settings/img/cards/card001.jpg <br />
-- example;
+- An error returns an error object such as:
+```
+{
+    "code": WizAssetsError value,
+    "status": if code is a HTTP_REQUEST_ERROR, the status of the HTPP request, optional
+    "message": description of the error if any
+}
+```
 
+**Example**
 ``` 
 wizAssets.downloadFile("http://google.com/logo.jpg", "img/ui/logo.jpg", successCallback, failCallback);
 ```
 
-### deleteFile()
-
-**wizAssets.deleteFile(string assetId, Function success, Function fail);**
+### wizAssets.deleteFile(assetId, success, fail)
 
 - deletes the file specified by the asset id <br />
 - if the asset id does not exist fail will be called with error NotFoundError <br />
-- if the asset id cannot be deleted (i.e. file resides in read-only memory) fail will be called with error NotModificationAllowedError
+- if the asset id cannot be deleted (i.e. file resides in read-only memory) fail will be called with an error message
 
+
+**Example**
 ```
-wizAssets.deleteFile("file://documents/settings/img/cards/card001.jpg", successCallback, failCallback);
+wizAssets.deleteFile("img/cards/card001.jpg", successCallback, failCallback);
 ```
 
-### deleteFiles()
+### wizAssets.deleteFiles(assetIds, success, fail)
 
-**wizAssets.deleteFiles(Array assetIds, Function success, Function fail );**
-
-- delete files specified by their asset id in Array like; [ "img/cards/card001.jpg", "img/cards/card002.jpg " .. ] <br />
+- delete files specified by their asset id in Array <br />
 - if an asset id uses a path format and matches a folder, then the folder content will be deleted; img/cards <br />
+- if an asset id cannot be deleted (i.e. file resides in read-only memory) fail will be called with an error message
 - the array CAN contain one asset id
 
-### getFileURI()
+**Example**
+```
+wizAssets.deleteFiles(["img/cards/card001.jpg", "img/cards/card002.jpg"], successCallback, failCallback);
+```
 
-**wizAssets.getFileURI(String assetId, Function success, Function fail);**
+### wizAssets.getFileURI(assetId, success, fail)
 
 - A success returns a local URL string like file://documents/settings/img/cards/card001.jpg <br />
-- example;
+- A failure returns an error message
 
+**Example**
 ```
 wizAssets.getFileURI("img/ui/logo.jpg", successCallback, failCallback);
 ```
 
-### getFileURIs()
-
-**wizAssets.getFileURIs(Function success, Function fail);**
+### wizAssets.getFileURIs(success, fail)
 
 - A success returns a hashmap of asset id matching its local URL such as
+- A failure returns an error message
 
 ```
 {
@@ -77,5 +85,36 @@ wizAssets.getFileURI("img/ui/logo.jpg", successCallback, failCallback);
     "img/ui/loader.gif"  : "/sdcard/<appname>/img/ui/loading.gif", 
     "img/cards/card001.jpg" : "file://documents/settings/img/cards/card001.jpg" 
 
-} 
+}
 ```
+
+**Example**
+```
+wizAssets.getFileURIs(successCallback, failCallback);
+```
+
+### Error handling
+
+All error codes are available via ```window.WizAssetsError```.
+
+**Example**
+```
+function fail(error) {
+    if (error.code === window.WizAssetsError.HTTP_REQUEST_ERROR) {
+        // Check error.status
+    } else {
+        // Log error code with error.message
+    }
+}
+```
+
+| Code | Constant                     | Description                                                                                            |
+|-----:|:-----------------------------|:-------------------------------------------------------------------------------------------------------|
+|    1 | `ARGS_MISSING_ERROR`         | Arguments are missing in your call to WizAssets' method                                                |
+|    2 | `INVALID_URL_ERROR`          | Specified URL to download is invald                                                                    |
+|    3 | `CONNECTIVITY_ERROR`         | Download could not be processed because network could not be accessed                                  |
+|    4 | `HTTP_REQUEST_ERROR`         | HTTP status of the request is not successful (not 2XX)                                                 |
+|    5 | `HTTP_REQUEST_CONTENT_ERROR` | Content received in HTTP request could not be read                                                     |
+|    6 | `DIRECTORY_CREATION_ERROR`   | Creation of the directory to save the asset failed                                                     |
+|    7 | `FILE_CREATION_ERROR`        | Saving the asset failed                                                                                |
+|    8 | `JSON_CREATION_ERROR`        | Your call to WizAssets' method failed and its error could not be processed internally                  |

--- a/platforms/ios/HelloCordova.xcodeproj/project.pbxproj
+++ b/platforms/ios/HelloCordova.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		308D05391370CCF300D202BF /* icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 308D05301370CCF300D202BF /* icon@2x.png */; };
 		30A0434814DC770100060A13 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 30A0434314DC770100060A13 /* Localizable.strings */; };
 		30FC414916E50CA1004E6F35 /* icon-72@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 30FC414816E50CA1004E6F35 /* icon-72@2x.png */; };
-		419DE3071A1D838F005428C9 /* WizAssetsPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 419DE3051A1D838F005428C9 /* WizAssetsPlugin.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		419DE3071A1D838F005428C9 /* WizAssetsPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = 419DE3051A1D838F005428C9 /* WizAssetsPlugin.m */; };
 		5B1594DD16A7569C00FEF299 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B1594DC16A7569C00FEF299 /* AssetsLibrary.framework */; };
 		7E7966DE1810823500FA85AD /* icon-40.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966D41810823500FA85AD /* icon-40.png */; };
 		7E7966DF1810823500FA85AD /* icon-40@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966D51810823500FA85AD /* icon-40@2x.png */; };

--- a/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h
+++ b/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h
@@ -11,8 +11,22 @@
 #import <UIKit/UIKit.h>
 #import <Cordova/CDVPlugin.h>
 
+enum CDVWizAssetsError {
+    NO_ERROR = 0,
+    ARGS_MISSING_ERROR = 1,
+    INVALID_URL_ERROR = 2,
+    CONNECTIVITY_ERROR = 3,
+    HTTP_REQUEST_ERROR = 4,
+    HTTP_REQUEST_CONTENT_ERROR = 5,
+    DIRECTORY_CREATION_ERROR = 6,
+    FILE_CREATION_ERROR = 7,
+    JSON_CREATION_ERROR = 8
+};
+typedef int CDVWizAssetsError;
+
 @interface WizAssetsPlugin : CDVPlugin <UIWebViewDelegate> {
     NSString *_cachePath;
+    NSURLSession *_session;
 }
 
 - (void)pluginInitialize;
@@ -25,5 +39,6 @@
 - (void)deleteFiles:(CDVInvokedUrlCommand *)command;
 
 @property (nonatomic, retain) NSString *cachePath;
+@property (nonatomic, retain) NSURLSession *session;
 
 @end

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,6 +18,9 @@
     <js-module src="www/phonegap/plugin/wizAssets/wizAssets.js" name="wizAssetsPlugin" target="phonegap/plugin/wizAssets/wizAssets.js">
         <clobbers target="window.wizAssets" />
     </js-module>
+    <js-module src="www/phonegap/plugin/wizAssets/WizAssetsError.js" name="WizAssetsError" target="phonegap/plugin/wizAssets/WizAssetsError.js">
+        <clobbers target="window.WizAssetsError" />
+    </js-module>
 
     <!-- ios -->
     <platform name="ios">
@@ -32,10 +35,10 @@
 
         <!-- Plugin files -->
         <header-file src="platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h" />
-        <source-file src="platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m" compiler-flags="-fno-objc-arc" />
+        <source-file src="platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m" />
 
         <!-- Logger -->
-        <source-file src="platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizDebugLog.h" compiler-flags="-fno-objc-arc" />
+        <source-file src="platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizDebugLog.h" />
 
     </platform>
 

--- a/www/phonegap/plugin/wizAssets/WizAssetsError.js
+++ b/www/phonegap/plugin/wizAssets/WizAssetsError.js
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Wizcorp Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+/**
+ * WizAssetsError
+ */
+function WizAssetsError(error) {
+  this.code = error || null;
+}
+
+// WizAssets error codes
+WizAssetsError.ARGS_MISSING_ERROR = 1;
+WizAssetsError.INVALID_URL_ERROR = 2;
+WizAssetsError.CONNECTIVITY_ERROR = 3;
+WizAssetsError.HTTP_REQUEST_ERROR = 4;
+WizAssetsError.HTTP_REQUEST_CONTENT_ERROR = 5;
+WizAssetsError.DIRECTORY_CREATION_ERROR = 6;
+WizAssetsError.FILE_CREATION_ERROR = 7;
+WizAssetsError.JSON_CREATION_ERROR = 8;
+
+module.exports = WizAssetsError;

--- a/www/phonegap/plugin/wizAssets/wizAssets.js
+++ b/www/phonegap/plugin/wizAssets/wizAssets.js
@@ -12,7 +12,13 @@ var wizAssets = {
     downloadFile: function (url, filePath, s, f) {
         window.setTimeout(
             function () {
-                exec(s, f, "WizAssetsPlugin", "downloadFile", [url, filePath]);
+                function failure(error) {
+                    if (error === WizAssetsError.JSON_CREATION_ERROR) {
+                        error = new WizAssetsError(error);
+                    }
+                    return f(error);
+                }
+                exec(s, failure, "WizAssetsPlugin", "downloadFile", [url, filePath]);
             }, 0);
     },
     deleteFile: function (uri, s, f) {


### PR DESCRIPTION
## Major
- ```downloadFile``` now uses NSURLSession API to download files on iOS. If the HTTP request fails, it returns the HTTP code. Otherwise we return the same ```success``` answer. (iOS)
- ```downloadFile``` errors returned have been updated on Android to match iOS behaviour (Android)

poke @Tatsujinichi and @ronkorving 