### PR TITLE
Asset path fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ PhoneGap plugin for managing application assets with javascript asset maps. Incl
 ## APIs
 
 
-### wizAssets.isReady(success, fail)
+### wizAssets.initialize(success, fail)
 
-- It's recommended to call this method first to know if plugin initialization went well. In some rare corner cases (if device storage is not writable for an unknown reason for instance) it can fail.
+- Call this method first to know if plugin initialization went well. In some rare corner cases (if device storage is not writable for an unknown reason for instance) it can fail.
 - If initialization failed, any other API call will call the error callback.
 
 **Example**
 ```javascript
-wizAssets.isReady(function () {
+wizAssets.initialize(function () {
         console.log('wiz assets is ready to be used');
     }, function () {
         console.log('wiz assets did not initialize, it cannot be used');

--- a/README.md
+++ b/README.md
@@ -10,24 +10,40 @@ PhoneGap plugin for managing application assets with javascript asset maps. Incl
 
 ## Install (with Plugman) 
 
-	cordova plugin add https://github.com/Wizcorp/phonegap-plugin-wizAssets
-	cordova build ios
-	
-	< or >
-	
-	phonegap local plugin add https://github.com/Wizcorp/phonegap-plugin-wizAssets
-	phonegap build ios
+    cordova plugin add https://github.com/Wizcorp/phonegap-plugin-wizAssets
+    cordova build ios
+    
+    < or >
+    
+    phonegap local plugin add https://github.com/Wizcorp/phonegap-plugin-wizAssets
+    phonegap build ios
 
 
 
 ## APIs
+
+
+### wizAssets.isReady(success, fail)
+
+- It's recommended to call this method first to know if plugin initialization went well. In some rare corner cases (if device storage is not writable for an unknown reason for instance) it can fail.
+- If initialization failed, any other API call will call the error callback.
+
+**Example**
+```javascript
+wizAssets.isReady(function () {
+        console.log('wiz assets is ready to be used');
+    }, function () {
+        console.log('wiz assets did not initialize, it cannot be used');
+    }
+);
+```
 
 ### wizAssets.downloadFile(remoteURL, assetId, success, fail)
 
 - downloads a file to native App directory @ ./ + gameDir+ / + assetId <br />
 - A success returns a local URL string like; file://documents/settings/img/cards/card001.jpg <br />
 - An error returns an error object such as:
-```
+```javascript
 {
     "code": WizAssetsError value,
     "status": if code is a HTTP_REQUEST_ERROR, the status of the HTPP request, optional
@@ -36,7 +52,7 @@ PhoneGap plugin for managing application assets with javascript asset maps. Incl
 ```
 
 **Example**
-``` 
+``` javascript
 wizAssets.downloadFile("http://google.com/logo.jpg", "img/ui/logo.jpg", successCallback, failCallback);
 ```
 
@@ -48,7 +64,7 @@ wizAssets.downloadFile("http://google.com/logo.jpg", "img/ui/logo.jpg", successC
 
 
 **Example**
-```
+```javascript
 wizAssets.deleteFile("img/cards/card001.jpg", successCallback, failCallback);
 ```
 
@@ -60,7 +76,7 @@ wizAssets.deleteFile("img/cards/card001.jpg", successCallback, failCallback);
 - the array CAN contain one asset id
 
 **Example**
-```
+```javascript
 wizAssets.deleteFiles(["img/cards/card001.jpg", "img/cards/card002.jpg"], successCallback, failCallback);
 ```
 
@@ -70,7 +86,7 @@ wizAssets.deleteFiles(["img/cards/card001.jpg", "img/cards/card002.jpg"], succes
 - A failure returns an error message
 
 **Example**
-```
+```javascript
 wizAssets.getFileURI("img/ui/logo.jpg", successCallback, failCallback);
 ```
 
@@ -79,7 +95,7 @@ wizAssets.getFileURI("img/ui/logo.jpg", successCallback, failCallback);
 - A success returns a hashmap of asset id matching its local URL such as
 - A failure returns an error message
 
-```
+```javascript
 {
 
     "img/ui/loader.gif"  : "/sdcard/<appname>/img/ui/loading.gif", 
@@ -89,7 +105,7 @@ wizAssets.getFileURI("img/ui/logo.jpg", successCallback, failCallback);
 ```
 
 **Example**
-```
+```javascript
 wizAssets.getFileURIs(successCallback, failCallback);
 ```
 
@@ -98,7 +114,7 @@ wizAssets.getFileURIs(successCallback, failCallback);
 All error codes are available via ```window.WizAssetsError```.
 
 **Example**
-```
+```javascript
 function fail(error) {
     if (error.code === window.WizAssetsError.HTTP_REQUEST_ERROR) {
         // Check error.status
@@ -118,3 +134,5 @@ function fail(error) {
 |    6 | `DIRECTORY_CREATION_ERROR`   | Creation of the directory to save the asset failed                                                     |
 |    7 | `FILE_CREATION_ERROR`        | Saving the asset failed                                                                                |
 |    8 | `JSON_CREATION_ERROR`        | Your call to WizAssets' method failed and its error could not be processed internally                  |
+|    9 | `INITIALIZATION_ERROR`       | WizAssets initialization failed                                                                        |
+|   10 | `UNREFERENCED_ERROR`         | Unknown error: message string (error.message) will contains more information                           |

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
@@ -215,8 +215,7 @@ public class WizAssetManager {
             String filePath;
             while (cursor.moveToNext()) {
                 filePath = cursor.getString(cursor.getColumnIndex("filePath"));
-                File fileToDelete = new File(filePath);
-                if (fileToDelete.exists() && fileToDelete.delete()) {
+                if (new File(filePath).delete()) {
                     counter++;
                 }
             }

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
@@ -222,7 +222,7 @@ public class WizAssetManager {
             String filePath;
             while (cursor.moveToNext()) {
                 filePath = cursor.getString(cursor.getColumnIndex("filePath"));
-                if (new File(filePath).delete()) {
+                if (WizAssetsPlugin.deleteFile(new File(filePath))) {
                     counter++;
                 }
             }

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
@@ -44,25 +44,25 @@ public class WizAssetManager {
     boolean initialiseDatabase;
     Context that;
 
-    public WizAssetManager(Context context) {
+    public WizAssetManager(Context context, String pathToDatabase) {
         Log.d(TAG, "Booting Wizard Asset Manager.");
 
         // context is application context
         that = context;
-        DATABASE_EXTERNAL_FILE_PATH =  that.getCacheDir().getAbsolutePath();
-        Log.d(TAG, "external database file path -- " + DATABASE_EXTERNAL_FILE_PATH + File.separator + DATABASE_NAME);
-        initialiseDatabase = (new File(DATABASE_EXTERNAL_FILE_PATH + File.separator + DATABASE_NAME)).exists();
+        DATABASE_EXTERNAL_FILE_PATH = pathToDatabase;
+        Log.d(TAG, "external database file path -- " + DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME);
+        initialiseDatabase = (new File(DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME)).exists();
         if (initialiseDatabase == false) {
             buildDB();
         } else {
-            database = SQLiteDatabase.openDatabase(DATABASE_EXTERNAL_FILE_PATH + File.separator + DATABASE_NAME, null, SQLiteDatabase.OPEN_READWRITE);
+            database = SQLiteDatabase.openDatabase(DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME, null, SQLiteDatabase.OPEN_READWRITE);
             Log.d(TAG, "DB already initiated.");
         }
     }
 
     public JSONObject getAllAssets() {
 
-        // try to open database from external storage (we should have moved it there), 
+        // try to open database from external storage (we should have moved it there),
         // if nothing in the external storage move the app version out to external
         // if not existing internal, return empty object and we can stream the assets in
         JSONObject returnObject = new JSONObject();
@@ -79,7 +79,7 @@ public class WizAssetManager {
             while (cursor.moveToNext()) {
                 uri = cursor.getString(cursor.getColumnIndex("uri"));
                 filePath = cursor.getString(cursor.getColumnIndex("filePath"));
-                // push to object 
+                // push to object
                 try {
                     returnObject.put(uri, filePath);
                 } catch (JSONException e) {
@@ -89,7 +89,7 @@ public class WizAssetManager {
             }
 
             cursor.close();
-            Log.d(TAG, "returnObject -> " + returnObject.toString()); 
+            Log.d(TAG, "returnObject -> " + returnObject.toString());
 
         } catch (SQLiteException e3) {
             // ignore
@@ -108,7 +108,7 @@ public class WizAssetManager {
             InputStream is = that.getAssets().open(DATABASE_INTERNAL_FILE_PATH + DATABASE_NAME);
 
             // Copy the database into the destination
-            OutputStream os = new FileOutputStream(DATABASE_EXTERNAL_FILE_PATH + File.separator + DATABASE_NAME);
+            OutputStream os = new FileOutputStream(DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME);
 
             byte[] buffer = new byte[1024];
             int length;
@@ -120,7 +120,7 @@ public class WizAssetManager {
             os.close();
             is.close();
 
-            database = SQLiteDatabase.openDatabase(DATABASE_EXTERNAL_FILE_PATH + File.separator + DATABASE_NAME, null, SQLiteDatabase.OPEN_READWRITE);
+            database = SQLiteDatabase.openDatabase(DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME, null, SQLiteDatabase.OPEN_READWRITE);
             Log.d(TAG, "Init DB Finish");
 
         } catch (IOException e1) {
@@ -156,7 +156,7 @@ public class WizAssetManager {
         String result;
         try {
             if (cursor.moveToFirst()) {
-                result = cursor.getString(0);               
+                result = cursor.getString(0);
             } else {
                 // Cursor move error
                 result = "NotFoundError";

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
@@ -41,6 +41,10 @@ public class WizAssetManager {
     private static final String DATABASE_TABLE_NAME = "assets";
     private SQLiteDatabase database;
 
+    // previous versions constants
+    private static final String V5_0_0_DATABASE_NAME = "assets.db";
+    private static final String V5_0_0_DATABASE_TABLE_NAME = "assets";
+
     boolean initialiseDatabase;
     Context that;
 
@@ -59,6 +63,10 @@ public class WizAssetManager {
             database = SQLiteDatabase.openDatabase(DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME, null, SQLiteDatabase.OPEN_READWRITE);
             Log.d(TAG, "DB already initiated.");
         }
+    }
+
+    public boolean isReady() {
+        return (new File(DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME)).exists() && database.isOpen();
     }
 
     public JSONObject getAllAssets() {
@@ -201,7 +209,7 @@ public class WizAssetManager {
 
     // If we detect a data structure created by plugin version <= 5.0.0 we want to clean up
     private void checkForMigration() {
-        String deprecatedDbLocation = that.getCacheDir().getAbsolutePath() + File.separator + "assets.db";
+        String deprecatedDbLocation = that.getCacheDir().getAbsolutePath() + File.separator + V5_0_0_DATABASE_NAME;
         File deprecatedDbFile = new File(deprecatedDbLocation);
         if (!deprecatedDbFile.exists()) {
             return;
@@ -211,7 +219,7 @@ public class WizAssetManager {
         SQLiteDatabase deprecatedDb = SQLiteDatabase.openDatabase(deprecatedDbLocation, null, SQLiteDatabase.OPEN_READONLY);
         int counter = 0;
         try {
-            Cursor cursor = deprecatedDb.rawQuery("select * from assets", null);
+            Cursor cursor = deprecatedDb.rawQuery("select * from " + V5_0_0_DATABASE_TABLE_NAME, null);
             String filePath;
             while (cursor.moveToNext()) {
                 filePath = cursor.getString(cursor.getColumnIndex("filePath"));

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
@@ -199,7 +199,7 @@ public class WizAssetManager {
         }
     }
 
-    // If we detect a data structure created by a version of the plugin <= 5.0.0 we need to clean up
+    // If we detect a data structure created by plugin version <= 5.0.0 we want to clean up
     private void checkForMigration() {
         String deprecatedDbLocation = that.getCacheDir().getAbsolutePath() + File.separator + "assets.db";
         File deprecatedDbFile = new File(deprecatedDbLocation);
@@ -221,6 +221,7 @@ public class WizAssetManager {
                 }
             }
             cursor.close();
+            deprecatedDb.close();
         } catch (SQLiteException e3) {
             Log.e(TAG, "error -- " + e3.getMessage(), e3);
         }

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetManager.java
@@ -66,11 +66,10 @@ public class WizAssetManager {
     }
 
     public boolean isReady() {
-        return (new File(DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME)).exists() && database.isOpen();
+        return (new File(DATABASE_EXTERNAL_FILE_PATH + DATABASE_NAME)).exists() && database != null && database.isOpen();
     }
 
     public JSONObject getAllAssets() {
-
         // try to open database from external storage (we should have moved it there),
         // if nothing in the external storage move the app version out to external
         // if not existing internal, return empty object and we can stream the assets in

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
@@ -208,6 +208,9 @@ public class WizAssetsPlugin extends CordovaPlugin {
     }
 
     private String buildAssetFilePathFromUri(String uri) {
+        if (uri.charAt(0) == File.separatorChar) {
+            return pathToAssets + uri.substring(1);
+        }
         return pathToAssets + uri;
     }
 

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
@@ -55,7 +55,7 @@ public class WizAssetsPlugin extends CordovaPlugin {
     public static final String PLUGIN_FOLDER = "wizAssets";
     public static final String ASSETS_FOLDER = "assets";
 
-    private static final String INITIALIZE = "initialize";
+    private static final String IS_READY_ACTION = "isReady";
     private static final String DOWNLOAD_FILE_ACTION = "downloadFile";
     private static final String GET_FILE_URI_ACTION = "getFileURI";
     private static final String GET_FILE_URIS_ACTION = "getFileURIs";
@@ -71,6 +71,8 @@ public class WizAssetsPlugin extends CordovaPlugin {
     private static final int DIRECTORY_CREATION_ERROR = 6;
     private static final int FILE_CREATION_ERROR = 7;
     private static final int JSON_CREATION_ERROR = 8;
+    private static final int INITIALIZATION_ERROR = 9;
+    private static final int UNREFERENCED_ERROR = 10;
 
     private String pathToDatabase;
     private String pathToAssets;
@@ -123,13 +125,13 @@ public class WizAssetsPlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        if (action.equals(INITIALIZE) && initialized) {
+        if (action.equals(IS_READY_ACTION) && initialized) {
             callbackContext.success();
             return true;
         }
 
         if (!initialized) {
-            callbackContext.error("plugin failed to initialize");
+            callbackContext.error(INITIALIZATION_ERROR);
             return true;
         }
 

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
@@ -125,17 +125,15 @@ public class WizAssetsPlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        if (action.equals(IS_READY_ACTION) && initialized) {
-            callbackContext.success();
-            return true;
-        }
-
         if (!initialized) {
             callbackContext.error(INITIALIZATION_ERROR);
             return true;
         }
 
-        if (action.equals(DOWNLOAD_FILE_ACTION)) {
+        if (action.equals(IS_READY_ACTION)) {
+            callbackContext.success();
+            return true;
+        } else if (action.equals(DOWNLOAD_FILE_ACTION)) {
             final String url = args.getString(0);
             final String uri = args.getString(1);
             final CallbackContext _callbackContext = callbackContext;
@@ -159,9 +157,7 @@ public class WizAssetsPlugin extends CordovaPlugin {
                 }
             });
             return true;
-
         } else if (action.equals(GET_FILE_URI_ACTION)) {
-
             Log.d(TAG, "[getFileURI] search full file path for: "+ args.toString() );
             String asset = null;
 
@@ -180,25 +176,19 @@ public class WizAssetsPlugin extends CordovaPlugin {
                 callbackContext.success(asset);
             }
             return true;
-
         } else if (action.equals(GET_FILE_URIS_ACTION)) {
-
             // Return all assets as asset map object
             Log.d(TAG, "[getFileURIs] returning all assets as map");
             JSONObject assetObject = wizAssetManager.getAllAssets();
             callbackContext.success(assetObject);
             return true;
-
         } else if (action.equals(DELETE_FILES_ACTION)) {
-
             // Delete all files from given array
             Log.d(TAG, "[deleteFiles] *********** ");
             deleteFiles(args, callbackContext);
 
             return true;
-
         } else if (action.equals(DELETE_FILE_ACTION)) {
-
             Log.d(TAG, "[deleteFile] *********** " + args.getString(0));
             String uri = args.getString(0);
             try {

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
@@ -50,10 +50,12 @@ public class WizAssetsPlugin extends CordovaPlugin {
 
     private String TAG = "WizAssetsPlugin";
     private WizAssetManager wizAssetManager = null;
+    private boolean initialized = false;
 
     public static final String PLUGIN_FOLDER = "wizAssets";
     public static final String ASSETS_FOLDER = "assets";
 
+    private static final String INITIALIZE = "initialize";
     private static final String DOWNLOAD_FILE_ACTION = "downloadFile";
     private static final String GET_FILE_URI_ACTION = "getFileURI";
     private static final String GET_FILE_URIS_ACTION = "getFileURIs";
@@ -85,8 +87,10 @@ public class WizAssetsPlugin extends CordovaPlugin {
 
         if (!createFolderIfRequired(pathToDatabase)) {
             Log.e(TAG, "error -- unable to create folder: " + pathToDatabase);
+            return;
         } else if (!createFolderIfRequired(pathToAssets)) {
             Log.e(TAG, "error -- unable to create folder: " + pathToAssets);
+            return;
         }
 
         pathToDatabase += File.separator;
@@ -95,6 +99,8 @@ public class WizAssetsPlugin extends CordovaPlugin {
         setBlockSize();
 
         wizAssetManager = new WizAssetManager(applicationContext, pathToDatabase);
+
+        initialized = wizAssetManager.isReady();
     }
 
     @SuppressWarnings("deprecation")
@@ -117,6 +123,16 @@ public class WizAssetsPlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        if (action.equals(INITIALIZE) && initialized) {
+            callbackContext.success();
+            return true;
+        }
+
+        if (!initialized) {
+            callbackContext.error("plugin failed to initialize");
+            return true;
+        }
+
         if (action.equals(DOWNLOAD_FILE_ACTION)) {
             final String url = args.getString(0);
             final String uri = args.getString(1);

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
@@ -55,7 +55,7 @@ public class WizAssetsPlugin extends CordovaPlugin {
     public static final String PLUGIN_FOLDER = "wizAssets";
     public static final String ASSETS_FOLDER = "assets";
 
-    private static final String IS_READY_ACTION = "isReady";
+    private static final String INITIALIZE_ACTION = "initialize";
     private static final String DOWNLOAD_FILE_ACTION = "downloadFile";
     private static final String GET_FILE_URI_ACTION = "getFileURI";
     private static final String GET_FILE_URIS_ACTION = "getFileURIs";
@@ -130,7 +130,7 @@ public class WizAssetsPlugin extends CordovaPlugin {
             return true;
         }
 
-        if (action.equals(IS_READY_ACTION)) {
+        if (action.equals(INITIALIZE_ACTION)) {
             callbackContext.success();
             return true;
         } else if (action.equals(DOWNLOAD_FILE_ACTION)) {

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
@@ -267,7 +267,9 @@ public class WizAssetsPlugin extends CordovaPlugin {
 
     private boolean createFolderIfRequired(String folderPath) {
         File folder = new File(folderPath);
-        if (folder.exists()) { return true; }
+        if (folder.exists()) {
+            return folder.isDirectory();
+        }
         return folder.mkdir();
     }
 

--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
@@ -246,7 +246,7 @@ public class WizAssetsPlugin extends CordovaPlugin {
         }
     }
 
-    private boolean deleteFile(File file) {
+    public static boolean deleteFile(File file) {
         boolean deleteSucceed = true;
         if (file.isDirectory()) {
             String files[] = file.list();

--- a/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h
+++ b/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h
@@ -20,7 +20,9 @@ enum CDVWizAssetsError {
     HTTP_REQUEST_CONTENT_ERROR = 5,
     DIRECTORY_CREATION_ERROR = 6,
     FILE_CREATION_ERROR = 7,
-    JSON_CREATION_ERROR = 8
+    JSON_CREATION_ERROR = 8,
+    INITIALIZATION_ERROR = 9,
+    UNREFERENCED_ERROR = 10
 };
 typedef int CDVWizAssetsError;
 
@@ -32,7 +34,7 @@ typedef int CDVWizAssetsError;
 - (void)pluginInitialize;
 
 // Exposed to JavaScript
-- (void)initialize:(CDVInvokedUrlCommand *)command;
+- (void)isReady:(CDVInvokedUrlCommand *)command;
 - (void)downloadFile:(CDVInvokedUrlCommand *)command;
 - (void)getFileURI:(CDVInvokedUrlCommand *)command;
 - (void)getFileURIs:(CDVInvokedUrlCommand *)command;

--- a/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h
+++ b/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h
@@ -34,7 +34,7 @@ typedef int CDVWizAssetsError;
 - (void)pluginInitialize;
 
 // Exposed to JavaScript
-- (void)isReady:(CDVInvokedUrlCommand *)command;
+- (void)initialize:(CDVInvokedUrlCommand *)command;
 - (void)downloadFile:(CDVInvokedUrlCommand *)command;
 - (void)getFileURI:(CDVInvokedUrlCommand *)command;
 - (void)getFileURIs:(CDVInvokedUrlCommand *)command;

--- a/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h
+++ b/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.h
@@ -32,6 +32,7 @@ typedef int CDVWizAssetsError;
 - (void)pluginInitialize;
 
 // Exposed to JavaScript
+- (void)initialize:(CDVInvokedUrlCommand *)command;
 - (void)downloadFile:(CDVInvokedUrlCommand *)command;
 - (void)getFileURI:(CDVInvokedUrlCommand *)command;
 - (void)getFileURIs:(CDVInvokedUrlCommand *)command;

--- a/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m
@@ -31,6 +31,15 @@ NSString *const assetsErrorKey = @"plugins.wizassets.errors";
 }
 
 /*
+ * initialize - not doing anything (yet) on iOS
+ */
+- (void)initialize:(CDVInvokedUrlCommand *)command {
+    CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    return;
+}
+
+/*
  * downloadFile - download from an HTTP to app folder
  */
 - (void)downloadFile:(CDVInvokedUrlCommand *)command {
@@ -60,7 +69,7 @@ NSString *const assetsErrorKey = @"plugins.wizassets.errors";
     NSURLRequest *request = [NSURLRequest requestWithURL:URL];
 
     NSURLSessionDownloadTask *downloadTask = [self.session downloadTaskWithRequest:request
-                                                            completionHandler:
+                                                                 completionHandler:
                                               ^(NSURL *location, NSURLResponse *response, NSError *error) {
                                                   CDVPluginResult *result = nil;
                                                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
@@ -92,7 +101,7 @@ NSString *const assetsErrorKey = @"plugins.wizassets.errors";
                                                   dispatch_async(dispatch_get_main_queue(), ^{
                                                       [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
                                                   });
-    }];
+                                              }];
 
     [downloadTask resume];
 }

--- a/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m
@@ -31,9 +31,9 @@ NSString *const assetsErrorKey = @"plugins.wizassets.errors";
 }
 
 /*
- * initialize - not doing anything (yet) on iOS
+ * isReady - not doing anything (yet) on iOS, just returning true
  */
-- (void)initialize:(CDVInvokedUrlCommand *)command {
+- (void)isReady:(CDVInvokedUrlCommand *)command {
     CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
 }

--- a/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m
@@ -31,9 +31,9 @@ NSString *const assetsErrorKey = @"plugins.wizassets.errors";
 }
 
 /*
- * isReady - not doing anything (yet) on iOS, just returning true
+ * initialize - not doing anything (yet) on iOS, just returning true
  */
-- (void)isReady:(CDVInvokedUrlCommand *)command {
+- (void)initialize:(CDVInvokedUrlCommand *)command {
     CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
 }

--- a/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/WizAssetsPlugin/WizAssetsPlugin.m
@@ -36,7 +36,6 @@ NSString *const assetsErrorKey = @"plugins.wizassets.errors";
 - (void)initialize:(CDVInvokedUrlCommand *)command {
     CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-    return;
 }
 
 /*

--- a/www/phonegap/plugin/wizAssets/WizAssetsError.js
+++ b/www/phonegap/plugin/wizAssets/WizAssetsError.js
@@ -24,8 +24,25 @@
 /**
  * WizAssetsError
  */
-function WizAssetsError(error) {
-  this.code = error || null;
+function WizAssetsError(error, message) {
+	this.code = error || null;
+	this.message = message || null;
+}
+
+/**
+ * Generate a well formed WizAssetsError from any kind of input (number, string, object...)
+ * TODO: should normalize error types on native side
+ */
+WizAssetsError.generate = function WizAssetsErrorGenerate (error) {
+	if (typeof error === 'string') {
+		return new WizAssetsError(WizAssetsError.UNREFERENCED_ERROR, error);
+	} else if (typeof error === 'number') {
+		return new WizAssetsError(error);
+	} else if (error && error.code !== undefined) {
+		return error;
+	} else {
+		return new WizAssetsError(WizAssetsError.UNREFERENCED_ERROR, error && error.toString());
+	}
 }
 
 // WizAssets error codes
@@ -37,5 +54,7 @@ WizAssetsError.HTTP_REQUEST_CONTENT_ERROR = 5;
 WizAssetsError.DIRECTORY_CREATION_ERROR = 6;
 WizAssetsError.FILE_CREATION_ERROR = 7;
 WizAssetsError.JSON_CREATION_ERROR = 8;
+WizAssetsError.INITIALIZATION_ERROR = 9;
+WizAssetsError.UNREFERENCED_ERROR = 10;
 
 module.exports = WizAssetsError;

--- a/www/phonegap/plugin/wizAssets/wizAssets.js
+++ b/www/phonegap/plugin/wizAssets/wizAssets.js
@@ -10,31 +10,37 @@
 var exec = require("cordova/exec");
 var wizAssets = {
     initialize: function (s, f) {
-        return exec(s, f, "WizAssetsPlugin", "initialize", []);
+        return exec(s, function (error) {
+            return f(WizAssetsError.generate(error));
+        }, "WizAssetsPlugin", "initialize", []);
     },
     downloadFile: function (url, filePath, s, f) {
-        window.setTimeout(
-            function () {
-                function failure(error) {
-                    if (error === WizAssetsError.JSON_CREATION_ERROR) {
-                        error = new WizAssetsError(error);
-                    }
-                    return f(error);
-                }
-                exec(s, failure, "WizAssetsPlugin", "downloadFile", [url, filePath]);
-            }, 0);
+        return window.setTimeout(function () {
+            return exec(s, function (error) {
+                return return f(WizAssetsError.generate(error));
+            }, "WizAssetsPlugin", "downloadFile", [url, filePath]);
+        }, 0);
     },
     deleteFile: function (uri, s, f) {
-        return exec(s, f, "WizAssetsPlugin", "deleteFile", [uri]);
+        return exec(s, function (error) {
+            return f(WizAssetsError.generate(error));
+        }, "WizAssetsPlugin", "deleteFile", [uri]);
     },
     deleteFiles: function (uris, s, f) {
-        return exec(s, f, "WizAssetsPlugin", "deleteFiles", uris);
+        return exec(s, function (error) {
+            return f(WizAssetsError.generate(error));
+        }, "WizAssetsPlugin", "deleteFiles", uris);
     },
     getFileURIs: function (s, f) {
-        return exec(s, f, "WizAssetsPlugin", "getFileURIs", []);
+        return exec(s, function (error) {
+            return f(WizAssetsError.generate(error));
+        }, "WizAssetsPlugin", "getFileURIs", []);
     },
     getFileURI: function (uri, s, f) {
-        return exec(s, f, "WizAssetsPlugin", "getFileURI", [uri]);
+        return exec(s, function (error) {
+            return f(WizAssetsError.generate(error));
+        }, "WizAssetsPlugin", "getFileURI", [uri]);
     }
 };
+
 module.exports = wizAssets;

--- a/www/phonegap/plugin/wizAssets/wizAssets.js
+++ b/www/phonegap/plugin/wizAssets/wizAssets.js
@@ -9,10 +9,10 @@
  */
 var exec = require("cordova/exec");
 var wizAssets = {
-    initialize: function (s, f) {
+    isReady: function (s, f) {
         return exec(s, function (error) {
             return f(WizAssetsError.generate(error));
-        }, "WizAssetsPlugin", "initialize", []);
+        }, "WizAssetsPlugin", "isReady", []);
     },
     downloadFile: function (url, filePath, s, f) {
         return window.setTimeout(function () {

--- a/www/phonegap/plugin/wizAssets/wizAssets.js
+++ b/www/phonegap/plugin/wizAssets/wizAssets.js
@@ -8,7 +8,10 @@
  *
  */
 var exec = require("cordova/exec");
-var wizAssets = { 
+var wizAssets = {
+    initialize: function (s, f) {
+        return exec(s, f, "WizAssetsPlugin", "initialize", []);
+    },
     downloadFile: function (url, filePath, s, f) {
         window.setTimeout(
             function () {
@@ -25,13 +28,13 @@ var wizAssets = {
         return exec(s, f, "WizAssetsPlugin", "deleteFile", [uri]);
     },
     deleteFiles: function (uris, s, f) {
-        return exec(s, f, "WizAssetsPlugin", "deleteFiles", uris );
+        return exec(s, f, "WizAssetsPlugin", "deleteFiles", uris);
     },
     getFileURIs: function (s, f) {
-        return exec(s, f, "WizAssetsPlugin", "getFileURIs", [] );
+        return exec(s, f, "WizAssetsPlugin", "getFileURIs", []);
     },
     getFileURI: function (uri, s, f) {
-        return exec(s, f, "WizAssetsPlugin", "getFileURI", [uri] );
+        return exec(s, f, "WizAssetsPlugin", "getFileURI", [uri]);
     }
 };
 module.exports = wizAssets;

--- a/www/phonegap/plugin/wizAssets/wizAssets.js
+++ b/www/phonegap/plugin/wizAssets/wizAssets.js
@@ -9,10 +9,10 @@
  */
 var exec = require("cordova/exec");
 var wizAssets = {
-    isReady: function (s, f) {
+    initialize: function (s, f) {
         return exec(s, function (error) {
             return f(WizAssetsError.generate(error));
-        }, "WizAssetsPlugin", "isReady", []);
+        }, "WizAssetsPlugin", "initialize", []);
     },
     downloadFile: function (url, filePath, s, f) {
         return window.setTimeout(function () {

--- a/www/phonegap/plugin/wizAssets/wizAssets.js
+++ b/www/phonegap/plugin/wizAssets/wizAssets.js
@@ -17,7 +17,7 @@ var wizAssets = {
     downloadFile: function (url, filePath, s, f) {
         return window.setTimeout(function () {
             return exec(s, function (error) {
-                return return f(WizAssetsError.generate(error));
+                return f(WizAssetsError.generate(error));
             }, "WizAssetsPlugin", "downloadFile", [url, filePath]);
         }, 0);
     },


### PR DESCRIPTION
- All files created by the plugin on Android are now placed in a proper subfolder inside the app cache directory, folder called `wizAssets`.
- Database is not removed anymore when requesting the deletion of all assets in cache via `/`.
- Fixed paths problems when passing a file or directory with an uri starting with a slash.

Ping @jrouault for review.