### PR TITLE
Fix Local file url

### DIFF
--- a/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
+++ b/platforms/android/src/jp/wizcorp/phonegap/plugin/WizAssets/WizAssetsPlugin.java
@@ -439,7 +439,7 @@ public class WizAssetsPlugin extends CordovaPlugin {
                 } else {
                     String fileAbsolutePath = file.getAbsolutePath();
                     Log.d(TAG, "[DownloadedPlugin ] " + fileAbsolutePath);
-                    callbackContext.success(fileAbsolutePath);
+                    callbackContext.success(buildLocalFileUrl(fileAbsolutePath));
                 }
             } catch (JSONException e) {
                 this.callbackContext.error(JSON_CREATION_ERROR);


### PR DESCRIPTION
Fix the file url for the local file url on the callback to the client.

Bug introduce in https://github.com/Wizcorp/phonegap-plugin-wizAssets/pull/21/files#diff-6d5265fda5622042ce0f322512001a31R442

Releases: master